### PR TITLE
Bug fixes & minor changes

### DIFF
--- a/core/dialogue/living_room.dialogue
+++ b/core/dialogue/living_room.dialogue
@@ -59,7 +59,7 @@ elif Inventory.selected_item() == Inventory.Item.MAGNIFYING_GLASS
 elif Inventory.selected_item() == Inventory.Item.TICKLER
 	You approach with the [color=cyan]TICKLER[/color].
 	You: i know what'll improve your mood! [#emotion=neutral]
-	Meowzers: don't even think about it.
+	Meowzers: don't even think about it. [#emotion=unamused]
 else
 	Meowzers: ... [#emotion=neutral]
 	Meowzers: is this a fish?
@@ -287,7 +287,7 @@ You leave.
 do StageManager.fade_to_black()
 ...
 But what happened between you and Banana last summer??
-Find out in Chapter 2\: Slime & Crime
+Find out in Chapter 2\: Slime & Crime (coming soon)!
 do Global.reset_game()
 do StageManager.changeStage(StageManager.CREDITS)
 => END

--- a/core/scenes/credits.tscn
+++ b/core/scenes/credits.tscn
@@ -289,7 +289,7 @@ bbcode_enabled = true
 text = "[center][b][font_size={120}][font=\"res://assets/fonts/NicoPups-Regular.ttf\"]Slime & Shine[/font][/font_size][/b][center]
 [center][b][font_size={120}][font=\"res://assets/fonts/NicoPups-Regular.ttf\"]Made by 8-bit Falcons[/font][/font_size][/b][center]
 
-[b][font_size={80][font=\"res://assets/fonts/Kenney Mini.ttf\"]Executive [/font][/font_size][/b]
+[b][font_size={80][font=\"res://assets/fonts/Kenney Mini.ttf\"]Executives [/font][/font_size][/b]
 
 
 

--- a/core/scenes/garden.tscn
+++ b/core/scenes/garden.tscn
@@ -189,6 +189,7 @@ layer_0/tile_data = PackedInt32Array(458752, 2, 1, 458753, 131074, 1, 458755, 2,
 
 [node name="player" parent="TileMap" instance=ExtResource("2_6kqp5")]
 z_index = 1
+y_sort_enabled = true
 position = Vector2(320, 456)
 metadata/_edit_group_ = true
 
@@ -398,6 +399,8 @@ shape = SubResource("CircleShape2D_7o5hv")
 debug_color = Color(0.956863, 0, 0.52549, 0.419608)
 
 [node name="Shore" parent="." node_paths=PackedStringArray("status_bubble") instance=ExtResource("3_ecdiu")]
+z_index = 1
+y_sort_enabled = true
 position = Vector2(176, 145)
 status_bubble = NodePath("StatusBubble")
 metadata/_edit_group_ = true
@@ -418,23 +421,9 @@ dialogue_start = "shore"
 [node name="StatusBubble" parent="Shore" instance=ExtResource("11_lj1al")]
 position = Vector2(0, -22)
 
-[node name="Mud Pie" parent="." instance=ExtResource("3_ecdiu")]
-position = Vector2(-22, 240)
-idle_anim = "forward"
-
-[node name="Sprite2D" parent="Mud Pie" index="0"]
-frame = 6
-
-[node name="AnimationPlayer" parent="Mud Pie" index="2"]
-libraries = {
-"": SubResource("AnimationLibrary_qcjuj")
-}
-
-[node name="Actionable" parent="Mud Pie" index="3"]
-dialogue_resource = ExtResource("4_j4hx5")
-dialogue_start = "mud_pie"
-
 [node name="Sherbet" parent="." instance=ExtResource("3_ecdiu")]
+z_index = 1
+y_sort_enabled = true
 position = Vector2(255, 257)
 idle_anim = "right"
 metadata/_edit_group_ = true
@@ -451,6 +440,24 @@ libraries = {
 dialogue_resource = ExtResource("4_j4hx5")
 dialogue_start = "sherbet"
 
+[node name="Mud Pie" parent="." instance=ExtResource("3_ecdiu")]
+z_index = 1
+y_sort_enabled = true
+position = Vector2(-22, 240)
+idle_anim = "forward"
+
+[node name="Sprite2D" parent="Mud Pie" index="0"]
+frame = 6
+
+[node name="AnimationPlayer" parent="Mud Pie" index="2"]
+libraries = {
+"": SubResource("AnimationLibrary_qcjuj")
+}
+
+[node name="Actionable" parent="Mud Pie" index="3"]
+dialogue_resource = ExtResource("4_j4hx5")
+dialogue_start = "mud_pie"
+
 [node name="SFX" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("12_clusk")
 volume_db = 14.512
@@ -458,5 +465,5 @@ volume_db = 14.512
 [editable path="TileMap/player"]
 [editable path="LivingRoomDoor"]
 [editable path="Shore"]
-[editable path="Mud Pie"]
 [editable path="Sherbet"]
+[editable path="Mud Pie"]

--- a/core/scripts/anim_actionable.gd
+++ b/core/scripts/anim_actionable.gd
@@ -22,24 +22,24 @@ func _ready() -> void:
 
 
 # HACK: is there a better way of doing this?
-# disables monitoring so you can interact with actionables whose collision shapes
+# disables collisions so you can interact with actionables whose collision shapes
 # overlap with this tile. difficult to use signal because whether or not this is
 # enabled could depend on multiple different types of variables (states,
 # inventory items, etc.).
 # this seems a bit inefficient.
 func _process(delta: float) -> void:
 	if State.has_method(enabled_flag) and save_state.current_frame[global_position] < frames.size() - 1:
-		monitorable = State.call(enabled_flag)
+		$CollisionShape2D.disabled = not State.call(enabled_flag)
 
 
 func action(player) -> void:
 	if (not State.has_method(enabled_flag)) or State.call(enabled_flag):
-		if save_state.current_frame[global_position] < frames.size() - 1:
+		if save_state.current_frame[global_position] < (frames.size() - 1):
 			save_state.current_frame[global_position] += 1
 			sprite_2d.frame = frames[save_state.current_frame[global_position]]
 			
 			if save_state.current_frame.values().all(func(x): return x == frames.size() - 1):
 				save_state.all_actions_complete = true
 		else:
-			monitorable = false
+			$CollisionShape2D.disabled = true
 		Global.animated_actionable_interacted_with.emit()

--- a/core/scripts/player.gd
+++ b/core/scripts/player.gd
@@ -85,3 +85,10 @@ func _on_animation_player_animation_started(anim_name):
 	
 func _on_global_request_player_turn(dir: String):
 	update_anim(dir)
+
+func getBodies(area: Area2D) -> Array:
+	await get_tree().physics_frame
+	if area:
+		return area.get_overlapping_bodies()
+	else:
+		return []


### PR DESCRIPTION
- added y-sort to garden slimes so player wouldn't appear above their hats
- fixed bug that would prevent player from detecting newly-monitorable animated actionables if they were touching them at the moment they became monitorable (player would need to move off and back on). this was due to the list of overlapping bodies only updating once every physics frame, so it would not update after the actionables became monitorable until the player moved a tile.
- added 'coming soon' to ending text
- changed 'executive' to 'executives' in credits